### PR TITLE
Extend salary model to user defined ranges

### DIFF
--- a/src/examples/emi-flow-editor/components/ai-editor.js
+++ b/src/examples/emi-flow-editor/components/ai-editor.js
@@ -65,6 +65,8 @@ class AiEditor extends React.Component {
       onChangePredictionDataOptions,
       onChangeLang,
       onChangeMinSimilarity,
+      onChangeMinValue,
+      onChangeMaxValue,
       onChangeIntentResponses,
       onChangeCountry,
       aiServerHandlers,
@@ -128,6 +130,28 @@ class AiEditor extends React.Component {
                   name="min_similarity"
                   value={ai.prediction_data.min_similarity}
                   onChange={e => onChangeMinSimilarity(e.target.value)}
+                />
+              </label>
+            )}
+            {ai.prediction_data && 'min_value' in ai.prediction_data && (
+              <label>
+                Min Value:
+                <input
+                  type="number"
+                  name="min_value"
+                  value={ai.prediction_data.min_value}
+                  onChange={e => onChangeMinValue(e.target.value)}
+                />
+              </label>
+            )}
+            {ai.prediction_data && 'max_value' in ai.prediction_data && (
+              <label>
+                Min Value:
+                <input
+                  type="number"
+                  name="max_value"
+                  value={ai.prediction_data.max_value}
+                  onChange={e => onChangeMaxValue(e.target.value)}
                 />
               </label>
             )}

--- a/src/examples/emi-flow-editor/empathy.js
+++ b/src/examples/emi-flow-editor/empathy.js
@@ -129,6 +129,8 @@ const empathyDefaults = {
     country: 'AR',
     prediction_data: {
       intent_responses: {},
+      min_value: null,
+      max_value: null,
     },
   },
   secondary_v2: {

--- a/src/examples/emi-flow-editor/handlers/ai-handlers.js
+++ b/src/examples/emi-flow-editor/handlers/ai-handlers.js
@@ -51,14 +51,41 @@ const getAiHandlers = bwdlEditable => {
     });
   }.bind(bwdlEditable);
 
-  bwdlEditable.onChangeMinSimilarity = function(newValue) {
-    if (newValue !== '' && (newValue > 100 || newValue < 1)) {
+  bwdlEditable.onChangePredictionDataNumber = function(
+    field,
+    min,
+    max,
+    newValue
+  ) {
+    if (newValue !== '' && (newValue > max || newValue < min)) {
       return;
     }
 
     this.changeSelectedNode(node => {
-      node.ai.prediction_data.min_similarity = newValue;
+      node.ai.prediction_data[field] = newValue;
     });
+  }.bind(bwdlEditable);
+
+  bwdlEditable.onChangeMinSimilarity = function(newValue) {
+    this.onChangePredictionDataNumber('min_similarity', 1, 100, newValue);
+  }.bind(bwdlEditable);
+
+  bwdlEditable.onChangeMinValue = function(newValue) {
+    this.onChangePredictionDataNumber(
+      'min_value',
+      0,
+      Number.MAX_SAFE_INTEGER,
+      newValue
+    );
+  }.bind(bwdlEditable);
+
+  bwdlEditable.onChangeMaxValue = function(newValue) {
+    this.onChangePredictionDataNumber(
+      'max_value',
+      0,
+      Number.MAX_SAFE_INTEGER,
+      newValue
+    );
   }.bind(bwdlEditable);
 
   bwdlEditable.onChangeIntentResponses = function(newValue) {


### PR DESCRIPTION
Adding min_value and max_value properties inside `prediction_data` of salary models
![image](https://user-images.githubusercontent.com/60659646/79464954-1f67a500-7fd1-11ea-8110-865b6b8328a0.png)

It seems there's a visual support missing, but it should be similary to `min_similarity` AFAIK
![image](https://user-images.githubusercontent.com/60659646/79465395-a9b00900-7fd1-11ea-8b9c-57159866877a.png)
