### PR TITLE
Add document model

### DIFF
--- a/src/examples/emi-flow-editor/empathy.js
+++ b/src/examples/emi-flow-editor/empathy.js
@@ -42,6 +42,10 @@ const empathyDefaults = {
     lang: 'ES',
     country: 'AR',
   },
+  document: {
+    lang: 'ES',
+    country: 'AR'
+  },
   duration: {
     lang: 'ES',
     country: 'AR',


### PR DESCRIPTION
Document model extracts ONLY NUMBERS in a document. Used for Argentine DNI mostly.